### PR TITLE
Prefer running tests against live filesystem instead of mocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ rvm:
   - 2.1.5
   - 2.2.0
   - jruby-19mode
+env:
+  - FOG_MOCK=true
+  - FOG_MOCK=false

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require "bundler/gem_tasks"
 
 task :default => :test
 
-mock = ENV['FOG_MOCK'] || 'true'
+mock = ENV['FOG_MOCK'] || 'false'
 task :test do
   sh("export FOG_MOCK=#{mock} && bundle exec shindont")
 end

--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -8,6 +8,7 @@ end
 require File.expand_path('../../lib/fog/local', __FILE__)
 
 Bundler.require(:test)
+require 'tmpdir'
 
 Excon.defaults.merge!(:debug_request => true, :debug_response => true)
 

--- a/tests/local/models/directories_tests.rb
+++ b/tests/local/models/directories_tests.rb
@@ -2,16 +2,17 @@ Shindo.tests('Storage[:local] | directories', ["local"]) do
 
   pending if Fog.mocking?
 
-  @options = { :local_root => "/tmp/fogtests" }
+  @options = { :local_root => Dir.mktmpdir('fog-tests') }
   @collection = Fog::Storage::Local.new(@options).directories
 
   collection_tests(@collection, {:key => "fogdirtests"}, true)
 
   tests("#all") do
     tests("succeeds when :local_root does not exist").succeeds do
-      FileUtils.rm_rf(@options[:local_root])
+      FileUtils.remove_entry_secure(@options[:local_root])
       @collection.all
     end
   end
 
+  FileUtils.remove_entry_secure(@options[:local_root]) if File.directory?(@options[:local_root])
 end

--- a/tests/local/models/directory_tests.rb
+++ b/tests/local/models/directory_tests.rb
@@ -3,14 +3,18 @@ Shindo.tests('Storage[:local] | directory', ["local"]) do
   pending if Fog.mocking?
 
   before do
-    @options = { :local_root => '~/.fog' }
+    @options = { :local_root => Dir.mktmpdir('fog-tests') }
+  end
+
+  after do
+    FileUtils.remove_entry_secure @options[:local_root]
   end
 
   tests('save') do
-    returns(true) do
+    returns('directory') do
       connection = Fog::Storage::Local.new(@options)
       connection.directories.create(:key => 'directory')
-      connection.directories.create(:key => 'directory')
+      connection.directories.create(:key => 'directory').key
     end
   end
 end

--- a/tests/local/models/file_tests.rb
+++ b/tests/local/models/file_tests.rb
@@ -3,7 +3,11 @@ Shindo.tests('Storage[:local] | file', ["local"]) do
   pending if Fog.mocking?
 
   before do
-    @options = { :local_root => '~/.fog' }
+    @options = { :local_root => Dir.mktmpdir('fog-tests') }
+  end
+
+  after do
+    FileUtils.remove_entry_secure @options[:local_root]
   end
 
   tests('#public_url') do

--- a/tests/local/storage_tests.rb
+++ b/tests/local/storage_tests.rb
@@ -3,7 +3,11 @@ Shindo.tests('Local | storage') do
   pending if Fog.mocking?
 
   before do
-    @options = { :local_root => "~/.fog" }
+    @options = { :local_root => Dir.mktmpdir('fog-tests') }
+  end
+
+  after do
+    FileUtils.remove_entry_secure @options[:local_root]
   end
 
   tests('#endpoint') do


### PR DESCRIPTION
Since local filesystem is usually available for writing, it's preferable to run tests in live mode instead of using mocks. Travis will run both mocking and non-mocking tests.

There were some issues at least on my machine that prevented non-mocking tests to be run repeatedly and successfully on my machine. To fix this, the tests now use random temporary directories instead of hardcoded values. This should prevent leaking state between tests. The temporary directories are also cleaned up after tests.
