### PR TITLE
Add missing storage file to fix issue with fog-core

### DIFF
--- a/lib/fog/local/storage.rb
+++ b/lib/fog/local/storage.rb
@@ -1,0 +1,1 @@
+# This file was intentionally left blank


### PR DESCRIPTION
`fog-core` expects a file defining the service inside the provider folder.
Since we are dealing with a gemnized provider this require on `fog-core` is not necessary anymore because bundler will automatically load all the content of the gem.

So this file is just a temporary fix until we change how `fog-core` loads the providers and services.
