### PR TITLE
use FileUtils.mkdir_p

### DIFF
--- a/lib/fog/storage/local/models/file.rb
+++ b/lib/fog/storage/local/models/file.rb
@@ -55,7 +55,7 @@ module Fog
               break
             end
             pwd = Dir.pwd
-            if ::File.exist?(dir_path) && ::File.directory?(dir_path)
+            if ::File.directory?(dir_path)
               Dir.chdir(dir_path)
               if Dir.glob('*').empty?
                 Dir.rmdir(dir_path)

--- a/lib/fog/storage/local/models/file.rb
+++ b/lib/fog/storage/local/models/file.rb
@@ -85,19 +85,15 @@ module Fog
 
         def save(options = {})
           requires :body, :directory, :key
+
+          # Once 1.9.3 support is dropped, the following two lines
+          # can be replaced with `File.dirname(path)`
           dirs = path.split(::File::SEPARATOR)[0...-1]
-          dirs.length.times do |index|
-            dir_path = dirs[0..index].join(::File::SEPARATOR)
-            if dir_path.empty? # path starts with ::File::SEPARATOR
-              next
-            end
-            # create directory if it doesn't already exist
-            begin
-              Dir.mkdir(dir_path)
-            rescue Errno::EEXIST
-              raise unless ::File.directory?(dir_path)
-            end
-          end
+          dir_path = dirs.join(::File::SEPARATOR)
+
+          # Create all directories in file path that do not yet exist
+          FileUtils.mkdir_p(dir_path)
+
           file = ::File.new(path, 'wb')
           if body.is_a?(String)
             file.write(body)

--- a/tests/local/models/file_tests.rb
+++ b/tests/local/models/file_tests.rb
@@ -44,4 +44,16 @@ Shindo.tests('Storage[:local] | file', ["local"]) do
         file.public_url
       end
   end
+
+  tests('#save') do
+    tests('creates non-existent subdirs') do
+      returns(true) do
+        connection = Fog::Storage::Local.new(@options)
+        directory = connection.directories.new(:key => 'path1')
+        file = directory.files.new(:key => 'path2/file.rb', :body => "my contents")
+        file.save
+        File.exists?(@options[:local_root] + "/path1/path2/file.rb")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Was looking through the code and noticed code that looks like a copy of `FileUtils.mkdir_p`. I assume the custom handling that uses `File::SEPARATOR` is because of windows. It looks like the lowest currently supported ruby for this project is 1.9.3, and it looks like [`FileUtils.mkdir_p` 1.9.3](http://ruby-doc.org/stdlib-1.9.3/libdoc/fileutils/rdoc/FileUtils.html#method-c-mkdir_p) handles windows based on the comment in its source def.
