### PR TITLE
Use FileUtils.cp to copy tempfiles on save

### DIFF
--- a/lib/fog/local.rb
+++ b/lib/fog/local.rb
@@ -1,5 +1,6 @@
 require 'fog/core'
 require 'fileutils'
+require 'tempfile'
 require File.expand_path('../local/version', __FILE__)
 
 module Fog

--- a/lib/fog/storage/local/models/file.rb
+++ b/lib/fog/storage/local/models/file.rb
@@ -94,7 +94,7 @@ module Fog
           # Create all directories in file path that do not yet exist
           FileUtils.mkdir_p(dir_path)
 
-          if body.kind_of? ::File and ::File.exist?(body.path)
+          if (body.is_a?(::File) || body.is_a?(Tempfile)) && ::File.exist?(body.path)
             FileUtils.cp(body.path, path)
           else
             write_file(path, body)

--- a/tests/local/models/file_tests.rb
+++ b/tests/local/models/file_tests.rb
@@ -55,5 +55,25 @@ Shindo.tests('Storage[:local] | file', ["local"]) do
         File.exists?(@options[:local_root] + "/path1/path2/file.rb")
       end
     end
+
+    tests('with tempfile').returns('tempfile') do
+      connection = Fog::Storage::Local.new(@options)
+      directory = connection.directories.create(:key => 'directory')
+
+      tempfile = Tempfile.new(['file', '.txt'])
+      tempfile.write('tempfile')
+      tempfile.rewind
+
+      tempfile.instance_eval do
+        def read
+          raise 'must not be read'
+        end
+      end
+      file = directory.files.new(:key => 'tempfile.txt', :body => tempfile)
+      file.save
+      tempfile.close
+      tempfile.unlink
+      directory.files.get('tempfile.txt').body
+    end
   end
 end


### PR DESCRIPTION
Use `FileUtils.cp` to copy `Tempfile`s instead of reading them to memory.

Fixes #6. 
