### PR TITLE
read and write with streams rather than strings

### DIFF
--- a/lib/fog/storage/local/models/files.rb
+++ b/lib/fog/storage/local/models/files.rb
@@ -37,15 +37,16 @@ module Fog
               :key            => key,
               :last_modified  => ::File.mtime(path)
             }
-            if block_given?
-              file = ::File.open(path)
-              while (chunk = file.read(Excon::CHUNK_SIZE)) && yield(chunk); end
-              file.close
-              new(data)
-            else
-              body = ::File.read(path)
-              new(data.merge!(:body => body))
+
+            body = ""
+            ::File.open(path) do |file|
+              while (chunk = file.read(Excon::CHUNK_SIZE)) && (!block_given? || (block_given? && yield(chunk)))
+                body << chunk
+              end
             end
+            data.merge!(:body => body) if !block_given?
+
+            new(data)
           else
             nil
           end


### PR DESCRIPTION
Hi there. I am currently dealing with very large files and `File.read` and `File.write` crash with `EINVAL` errors when I use the fog local provider to persist and read those files (>20GB). I played around with it and realised that it is because this provider when reading reads the whole file into memory at once or tries to persist the whole file at once. Then I tried doing it rather with IO than strings and it works perfectly.

Will be happy to apply suggestions and improvements on comments.
