### PR TITLE
Allow fog-core 2.x

### DIFF
--- a/fog-local.gemspec
+++ b/fog-local.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'shindo',  '~> 0.3'
 
-  spec.add_dependency 'fog-core',  '~> 1.27'
+  spec.add_dependency 'fog-core',  '>= 1.27', '< 3.0'
 end


### PR DESCRIPTION
This allows `fog-local` to be used with `fog-core` 2.x.

Also see:

* fog/fog-aws#429