### PR TITLE
Fix File#destroy for hidden files

### DIFF
--- a/lib/fog/storage/local/models/file.rb
+++ b/lib/fog/storage/local/models/file.rb
@@ -60,13 +60,12 @@ module Fog
         end
 
         def rm_if_empty_dir(dir_path)
-          pwd = Dir.pwd
           if ::File.directory?(dir_path)
-            Dir.chdir(dir_path)
-            if Dir.glob('*').empty?
-              Dir.rmdir(dir_path)
-            end
-            Dir.chdir(pwd)
+            # NOTE: There’s Dir.empty?, but it is only available on Ruby 2.4+
+            entries = Dir.entries(dir_path)
+            is_empty = entries.empty? || entries.all? { |e| ['.', '..'].include?(e) }
+
+            Dir.rmdir(dir_path) if is_empty
           end
         end
 

--- a/lib/fog/storage/local/models/file.rb
+++ b/lib/fog/storage/local/models/file.rb
@@ -61,12 +61,18 @@ module Fog
 
         def rm_if_empty_dir(dir_path)
           if ::File.directory?(dir_path)
-            # NOTE: There’s Dir.empty?, but it is only available on Ruby 2.4+
-            entries = Dir.entries(dir_path)
-            is_empty = entries.empty? || entries.all? { |e| ['.', '..'].include?(e) }
-
-            Dir.rmdir(dir_path) if is_empty
+            Dir.rmdir(dir_path) if dir_empty?(dir_path)
           end
+        end
+
+        def dir_empty?(dir_path)
+          # NOTE: There’s Dir.empty?, but it is only available on Ruby 2.4+
+
+          # NOTE: `entries` will be empty on Windows, and contain . and .. on
+          # unix-like systems (macOS, Linux, BSD, …)
+
+          entries = Dir.entries(dir_path)
+          entries.empty? || entries.all? { |e| ['.', '..'].include?(e) }
         end
 
         def public=(new_public)

--- a/lib/fog/storage/local/models/file.rb
+++ b/lib/fog/storage/local/models/file.rb
@@ -54,16 +54,20 @@ module Fog
             if dir_path == service.path_to(directory.key)
               break
             end
-            pwd = Dir.pwd
-            if ::File.directory?(dir_path)
-              Dir.chdir(dir_path)
-              if Dir.glob('*').empty?
-                Dir.rmdir(dir_path)
-              end
-              Dir.chdir(pwd)
-            end
+            rm_if_empty_dir(dir_path)
           end
           true
+        end
+
+        def rm_if_empty_dir(dir_path)
+          pwd = Dir.pwd
+          if ::File.directory?(dir_path)
+            Dir.chdir(dir_path)
+            if Dir.glob('*').empty?
+              Dir.rmdir(dir_path)
+            end
+            Dir.chdir(pwd)
+          end
         end
 
         def public=(new_public)

--- a/lib/fog/storage/local/models/file.rb
+++ b/lib/fog/storage/local/models/file.rb
@@ -59,22 +59,6 @@ module Fog
           true
         end
 
-        def rm_if_empty_dir(dir_path)
-          if ::File.directory?(dir_path)
-            Dir.rmdir(dir_path) if dir_empty?(dir_path)
-          end
-        end
-
-        def dir_empty?(dir_path)
-          # NOTE: There’s Dir.empty?, but it is only available on Ruby 2.4+
-
-          # NOTE: `entries` will be empty on Windows, and contain . and .. on
-          # unix-like systems (macOS, Linux, BSD, …)
-
-          entries = Dir.entries(dir_path)
-          entries.empty? || entries.all? { |e| ['.', '..'].include?(e) }
-        end
-
         def public=(new_public)
           new_public
         end
@@ -133,6 +117,22 @@ module Fog
           ::File.open(path, 'wb') do |file|
             IO.copy_stream(input_io, file)
           end
+        end
+
+        def rm_if_empty_dir(dir_path)
+          if ::File.directory?(dir_path)
+            Dir.rmdir(dir_path) if dir_empty?(dir_path)
+          end
+        end
+
+        def dir_empty?(dir_path)
+          # NOTE: There’s Dir.empty?, but it is only available on Ruby 2.4+
+
+          # NOTE: `entries` will be empty on Windows, and contain . and .. on
+          # unix-like systems (macOS, Linux, BSD, …)
+
+          entries = Dir.entries(dir_path)
+          entries.empty? || entries.all? { |e| ['.', '..'].include?(e) }
         end
       end
     end

--- a/tests/local/models/file_tests.rb
+++ b/tests/local/models/file_tests.rb
@@ -76,4 +76,71 @@ Shindo.tests('Storage[:local] | file', ["local"]) do
       directory.files.get('tempfile.txt').body
     end
   end
+
+  tests('#destroy') do
+    # - removes dir if it contains no files
+    # - keeps dir if it contains non-hidden files
+    # - keeps dir if it contains hidden files
+    # - stays in the same directory
+
+    tests('removes enclosing dir if it is empty') do
+      returns(false) do
+        connection = Fog::Storage::Local.new(@options)
+        directory = connection.directories.new(:key => 'path1')
+
+        file = directory.files.new(:key => 'path2/file.rb', :body => "my contents")
+        file.save
+        file.destroy
+
+        File.exists?(@options[:local_root] + "/path1/path2")
+      end
+    end
+
+    tests('keeps enclosing dir if it is not empty') do
+      returns(true) do
+        connection = Fog::Storage::Local.new(@options)
+        directory = connection.directories.new(:key => 'path1')
+
+        file = directory.files.new(:key => 'path2/file.rb', :body => "my contents")
+        file.save
+
+        file = directory.files.new(:key => 'path2/file2.rb', :body => "my contents")
+        file.save
+        file.destroy
+
+        File.exists?(@options[:local_root] + "/path1/path2")
+      end
+    end
+
+    # FIXME: the following test fails
+
+    # tests('keeps enclosing dir if contains only hidden files') do
+    #   returns(true) do
+    #     connection = Fog::Storage::Local.new(@options)
+    #     directory = connection.directories.new(:key => 'path1')
+    #
+    #     file = directory.files.new(:key => 'path2/.file.rb', :body => "my contents")
+    #     file.save
+    #
+    #     file = directory.files.new(:key => 'path2/.file2.rb', :body => "my contents")
+    #     file.save
+    #     file.destroy
+    #
+    #     File.exists?(@options[:local_root] + "/path1/path2")
+    #   end
+    # end
+
+    tests('it stays in the same directory') do
+      returns(Dir.pwd) do
+        connection = Fog::Storage::Local.new(@options)
+        directory = connection.directories.new(:key => 'path1')
+
+        file = directory.files.new(:key => 'path2/file2.rb', :body => "my contents")
+        file.save
+        file.destroy
+
+        Dir.pwd
+      end
+    end
+  end
 end

--- a/tests/local/models/file_tests.rb
+++ b/tests/local/models/file_tests.rb
@@ -112,23 +112,21 @@ Shindo.tests('Storage[:local] | file', ["local"]) do
       end
     end
 
-    # FIXME: the following test fails
+    tests('keeps enclosing dir if contains only hidden files') do
+      returns(true) do
+        connection = Fog::Storage::Local.new(@options)
+        directory = connection.directories.new(:key => 'path1')
 
-    # tests('keeps enclosing dir if contains only hidden files') do
-    #   returns(true) do
-    #     connection = Fog::Storage::Local.new(@options)
-    #     directory = connection.directories.new(:key => 'path1')
-    #
-    #     file = directory.files.new(:key => 'path2/.file.rb', :body => "my contents")
-    #     file.save
-    #
-    #     file = directory.files.new(:key => 'path2/.file2.rb', :body => "my contents")
-    #     file.save
-    #     file.destroy
-    #
-    #     File.exists?(@options[:local_root] + "/path1/path2")
-    #   end
-    # end
+        file = directory.files.new(:key => 'path2/.file.rb', :body => "my contents")
+        file.save
+
+        file = directory.files.new(:key => 'path2/.file2.rb', :body => "my contents")
+        file.save
+        file.destroy
+
+        File.exists?(@options[:local_root] + "/path1/path2")
+      end
+    end
 
     tests('it stays in the same directory') do
       returns(Dir.pwd) do


### PR DESCRIPTION
`File#destroy` attempts to destroy the enclosing directory if it is empty. This fails when the directory contains hidden files, however.

This PR fixes that problem. It also:

* Refactors the code so that it no longer changes the current working directory
* Makes it work on Windows (though I haven’t figured out *why* it did not work on Windows)