### PR TITLE
Fix URI.escape deprecation

### DIFF
--- a/lib/fog/local.rb
+++ b/lib/fog/local.rb
@@ -1,4 +1,5 @@
 require 'fog/core'
+require 'erb'
 require 'fileutils'
 require 'tempfile'
 

--- a/lib/fog/local/models/file.rb
+++ b/lib/fog/local/models/file.rb
@@ -67,8 +67,8 @@ module Fog
           requires :directory, :key
 
           if service.endpoint
-            escaped_directory = URI.escape(directory.key)
-            escaped_key = URI.escape(key)
+            escaped_directory = ERB::Util.url_encode(directory.key)
+            escaped_key = ERB::Util.url_encode(key)
 
             ::File.join(service.endpoint, escaped_directory, escaped_key)
           else


### PR DESCRIPTION
Fix URI.escape deprecation by using ERB::Util.url_encode instead of URI.escape.