### PR TITLE
Enable CI on GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,4 @@ on:
 
 jobs:
   test:
-    uses: fog/.github/.github/workflows/ruby.yml@v1.4.0
+    uses: fog/.github/.github/workflows/ci.yml@v1.4.0


### PR DESCRIPTION
Currently, CI on this repo is not running https://github.com/fog/fog-local/actions/workflows/ruby.yml
since fog/.github workflow has been renamed from "ruby" to "ci" via https://github.com/fog/.github/commit/e2424dd8d7f59adff152f5f1aef16f24d32978c3

This patch enables the CI by following the upstream rename. Also, this patch renames the YAML filename from ruby.yml to ci.yml for better consistency with the upstream and other fog-* repos.