### PR TITLE
Use a mutable string to be used a string buffer for Ruby 3.4

### DIFF
--- a/lib/fog/local/models/files.rb
+++ b/lib/fog/local/models/files.rb
@@ -38,7 +38,7 @@ module Fog
               :last_modified  => ::File.mtime(path)
             }
 
-            body = ""
+            body = String.new
             ::File.open(path) do |file|
               while (chunk = file.read(Excon::CHUNK_SIZE)) && (!block_given? || (block_given? && yield(chunk)))
                 body << chunk


### PR DESCRIPTION
Ruby is slowly moving towards frozen string literals by default.
This is from [Ruby 3.4.0 release](https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/)

> String literals in files without a frozen_string_literal comment now emit a deprecation warning when they are mutated. These warnings can be enabled with -W:deprecated or by setting Warning[:deprecated] = true. To disable this change, you can run Ruby with the --disable-frozen-string-literal command line argument. [[Feature #20205](https://bugs.ruby-lang.org/issues/20205)]

Minitest has deprecation warnings enabled by default and therefore it is quite noisy without this fix.

With this, the code should be compatible with newer versions of Ruby as well as backward compatible.