### PR TITLE
Update uri_escape to work with Ruby 3.4

### DIFF
--- a/lib/fog/local/models/file.rb
+++ b/lib/fog/local/models/file.rb
@@ -107,7 +107,7 @@ module Fog
         end
 
         def uri_escape(string)
-          string.b.gsub(URI::DEFAULT_PARSER.regexp[:UNSAFE]) do |m|
+          string.b.gsub(/[^\-_.!~*'()a-zA-Z\d;\/?:@&=+$,\[\]]/) do |m|
             '%' + m.unpack('H2' * m.bytesize).join('%').upcase
           end
         end


### PR DESCRIPTION
the URI constant DEFAULT_PARSER changed in newer versions of URI.  I didn't see a simple backwards compatible way to reference the old constant, so I've inlined the regex

I'm open to cleaner ways of doing this.